### PR TITLE
Fix code scanning alert no. 128: Use of a broken or risky cryptographic algorithm

### DIFF
--- a/vuln_apps/vulnado/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/vuln_apps/vulnado/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -64,7 +64,7 @@ public class Postgres {
         try {
 
             // Static getInstance method is called with hashing MD5
-            MessageDigest md = MessageDigest.getInstance("MD5");
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
 
             // digest() method is called to calculate message digest
             //  of an input digest() return array of byte


### PR DESCRIPTION
Fixes [https://github.com/Merlyno1980/devsecops-exercises/security/code-scanning/128](https://github.com/Merlyno1980/devsecops-exercises/security/code-scanning/128)

To fix the problem, we need to replace the use of the weak MD5 algorithm with a stronger, modern cryptographic algorithm. The best way to fix this issue is to use SHA-256, which is a secure and widely recommended hashing algorithm.

- Replace `MessageDigest.getInstance("MD5")` with `MessageDigest.getInstance("SHA-256")`.
- Ensure that the rest of the code correctly handles the output of the SHA-256 hash, which is longer than the MD5 hash.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
